### PR TITLE
[FEAT] 온보딩 닉네임 페이지 완료

### DIFF
--- a/src/app/onBoarding/nickName/page.tsx
+++ b/src/app/onBoarding/nickName/page.tsx
@@ -3,13 +3,17 @@
 import Button from "@/components/atom/Button";
 import { S } from "./styles";
 import { ChangeEvent, useState } from "react";
+import { MAX_LENGTH } from "@/constant/common/textLength";
 
 function NickNameOnBoarding() {
   const [nickNameLength, setNickNameLength] = useState("");
+  const [focusInput, setFocusInput] = useState(false);
 
   const handleInputValue = (e: ChangeEvent<HTMLInputElement>) => {
+    if (e.target.value.length > MAX_LENGTH) {
+      e.target.value = e.target.value.slice(0, MAX_LENGTH);
+    }
     setNickNameLength(e.target.value);
-    console.log(nickNameLength, nickNameLength.length);
   };
 
   return (
@@ -19,16 +23,25 @@ function NickNameOnBoarding() {
         <S.NicknameLabel>
           반가워요! 당신을 뭐라고 부르면 좋을까요?
         </S.NicknameLabel>
-        <S.NickNameInputWrap>
-          <input
-            maxLength={10}
-            value={nickNameLength}
-            placeholder="2~10자 닉네임을 입력해주세요"
-            onChange={handleInputValue}
+        <S.FormWrap>
+          <S.NickNameInputWrap>
+            <input
+              maxLength={MAX_LENGTH}
+              value={nickNameLength}
+              placeholder="2~10자 닉네임을 입력해주세요"
+              onFocus={() => setFocusInput(true)}
+              onBlur={() => setFocusInput(false)}
+              onChange={handleInputValue}
+            />
+            {focusInput && <span>{nickNameLength.length}/10</span>}
+          </S.NickNameInputWrap>
+          <Button
+            type="submit"
+            disabled={nickNameLength.length === 0}
+            buttonText="다음으로"
+            size="primary"
           />
-          <span>{nickNameLength.length}/10</span>
-        </S.NickNameInputWrap>
-        <Button type="submit" buttonText="다음으로" />
+        </S.FormWrap>
       </S.Wrapper>
     </>
   );

--- a/src/app/onBoarding/nickName/page.tsx
+++ b/src/app/onBoarding/nickName/page.tsx
@@ -1,8 +1,35 @@
+"use client";
+
+import Button from "@/components/atom/Button";
+import { S } from "./styles";
+import { ChangeEvent, useState } from "react";
+
 function NickNameOnBoarding() {
+  const [nickNameLength, setNickNameLength] = useState("");
+
+  const handleInputValue = (e: ChangeEvent<HTMLInputElement>) => {
+    setNickNameLength(e.target.value);
+    console.log(nickNameLength, nickNameLength.length);
+  };
+
   return (
     <>
       <div>NavHeader</div>
-      <div>NickNameOnBoarding</div>
+      <S.Wrapper>
+        <S.NicknameLabel>
+          반가워요! 당신을 뭐라고 부르면 좋을까요?
+        </S.NicknameLabel>
+        <S.NickNameInputWrap>
+          <input
+            maxLength={10}
+            value={nickNameLength}
+            placeholder="2~10자 닉네임을 입력해주세요"
+            onChange={handleInputValue}
+          />
+          <span>{nickNameLength.length}/10</span>
+        </S.NickNameInputWrap>
+        <Button type="submit" buttonText="다음으로" />
+      </S.Wrapper>
     </>
   );
 }

--- a/src/app/onBoarding/nickName/page.tsx
+++ b/src/app/onBoarding/nickName/page.tsx
@@ -1,0 +1,9 @@
+function NickNameOnBoarding() {
+  return (
+    <>
+      <div>NavHeader</div>
+      <div>NickNameOnBoarding</div>
+    </>
+  );
+}
+export default NickNameOnBoarding;

--- a/src/app/onBoarding/nickName/styles.ts
+++ b/src/app/onBoarding/nickName/styles.ts
@@ -1,0 +1,39 @@
+import { theme } from "@/styles/theme";
+import styled from "@emotion/styled";
+
+const Wrapper = styled.form`
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 90%;
+`;
+
+const NicknameLabel = styled.div`
+  font-size: ${theme.fontSize.lg};
+  font-weight: ${theme.fontWeight.bold};
+  width: 25rem;
+`;
+
+const NickNameInputWrap = styled.div`
+  display: flex;
+  width: 100%;
+  background-color: ${theme.color.white};
+  align-items: center;
+  padding: 1rem;
+  border: 1px solid ${theme.color.grayColor[200]};
+  border-radius: 0.8rem;
+
+  & > input {
+    border: none;
+    background: none;
+    width: 36.1rem;
+    height: 4rem;
+    margin-right: 1rem;
+  }
+`;
+
+export const S = {
+  Wrapper,
+  NicknameLabel,
+  NickNameInputWrap,
+};

--- a/src/app/onBoarding/nickName/styles.ts
+++ b/src/app/onBoarding/nickName/styles.ts
@@ -4,8 +4,9 @@ import styled from "@emotion/styled";
 const Wrapper = styled.form`
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  width: 90%;
+  align-items: start;
+  width: 100%;
+  padding: 2rem;
 `;
 
 const NicknameLabel = styled.div`
@@ -16,24 +17,34 @@ const NicknameLabel = styled.div`
 
 const NickNameInputWrap = styled.div`
   display: flex;
-  width: 100%;
+  width: 36rem;
   background-color: ${theme.color.white};
   align-items: center;
   padding: 1rem;
+  margin: 6rem 0;
   border: 1px solid ${theme.color.grayColor[200]};
   border-radius: 0.8rem;
 
   & > input {
     border: none;
     background: none;
-    width: 36.1rem;
+    width: 100%;
     height: 4rem;
     margin-right: 1rem;
   }
 `;
 
+const FormWrap = styled.div`
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+`;
+
 export const S = {
   Wrapper,
+  FormWrap,
   NicknameLabel,
   NickNameInputWrap,
 };

--- a/src/components/atom/Button/index.tsx
+++ b/src/components/atom/Button/index.tsx
@@ -1,0 +1,63 @@
+import React, { CSSProperties } from "react";
+import styled from "@emotion/styled";
+import { theme } from "@/styles/theme";
+
+function Button({
+  clickCallback,
+  buttonText,
+  disabled,
+  className,
+  type,
+  styleProps,
+}: {
+  clickCallback?: () => void;
+  buttonText: string;
+  disabled?: boolean;
+  className?: string;
+  type?: "button" | "submit" | "reset" | undefined;
+  styleProps?: CSSProperties;
+}) {
+  return (
+    <ButtonBox className={className}>
+      <button
+        style={{ ...styleProps }}
+        disabled={disabled}
+        onClick={() => clickCallback?.()}
+        type={type ?? "button"}
+      >
+        {buttonText}
+      </button>
+    </ButtonBox>
+  );
+}
+
+export default Button;
+
+const ButtonBox = styled.div<{
+  color?: string;
+  type?: string;
+}>`
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+
+  & > button {
+    display: flex;
+    background-color: ${theme.color.primary};
+    flex-direction: row;
+    cursor: pointer;
+    justify-content: space-between;
+    align-items: center;
+    border: none;
+    outline: none;
+    color: ${theme.color.white};
+
+    &:disabled {
+      cursor: not-allowed;
+      background-color: ${theme.color.grayColor[200]};
+      user-select: none;
+      opacity: 0.6;
+    }
+  }
+`;

--- a/src/components/atom/Button/index.tsx
+++ b/src/components/atom/Button/index.tsx
@@ -1,6 +1,8 @@
+/** @jsxImportSource @emotion/react */
 import React, { CSSProperties } from "react";
 import styled from "@emotion/styled";
 import { theme } from "@/styles/theme";
+import sizeCSS from "./styles";
 
 function Button({
   clickCallback,
@@ -8,18 +10,22 @@ function Button({
   disabled,
   className,
   type,
+  size,
   styleProps,
 }: {
   clickCallback?: () => void;
   buttonText: string;
   disabled?: boolean;
   className?: string;
+  size?: "primary" | undefined;
   type?: "button" | "submit" | "reset" | undefined;
   styleProps?: CSSProperties;
 }) {
   return (
     <ButtonBox className={className}>
       <button
+        // eslint-disable-next-line react/no-unknown-property
+        css={size ? sizeCSS[size] : undefined}
         style={{ ...styleProps }}
         disabled={disabled}
         onClick={() => clickCallback?.()}
@@ -47,7 +53,7 @@ const ButtonBox = styled.div<{
     background-color: ${theme.color.primary};
     flex-direction: row;
     cursor: pointer;
-    justify-content: space-between;
+    justify-content: center;
     align-items: center;
     border: none;
     outline: none;

--- a/src/components/atom/Button/styles.ts
+++ b/src/components/atom/Button/styles.ts
@@ -1,0 +1,13 @@
+import { theme } from "@/styles/theme";
+import { SerializedStyles, css } from "@emotion/react";
+
+const sizeCSS: Record<string, SerializedStyles> = {
+  primary: css`
+    width: 36rem;
+    height: 6rem;
+    padding: 16px 0;
+    border-radius: 0.8rem;
+    font-size: ${theme.fontSize.md};
+  `,
+};
+export default sizeCSS;

--- a/src/constant/common/textLength.ts
+++ b/src/constant/common/textLength.ts
@@ -1,0 +1,1 @@
+export const MAX_LENGTH = 10;


### PR DESCRIPTION
## 📝작업 내용

- 온보딩 닉네임 페이지 완료
- 버튼 컴포넌트 로직 일부 수정
- textLength 상수 관리 용도로 common 폴더 안에 생성

### 스크린샷 (선택)
<img width="409" alt="스크린샷 2024-05-15 오후 10 49 58" src="https://github.com/perfume-pick/purple-front/assets/117560052/4ab9d853-c984-4359-8061-46038336e198">

<img width="409" alt="스크린샷 2024-05-15 오후 10 52 07" src="https://github.com/perfume-pick/purple-front/assets/117560052/9571d42a-424b-4a15-8c55-0796948431f6">


