### PR TITLE
[FIX] 기본 이미지로 프로필 수정 요청시 에러 수정

### DIFF
--- a/src/app/myPage/profileSetting/page.tsx
+++ b/src/app/myPage/profileSetting/page.tsx
@@ -10,7 +10,7 @@ import ValidatedInput from "./_components/ValidatedInput/ValidatedInput";
 import HeaderBottomContents from "@/components/headerBottomContents/HeaderBottomContents";
 import ProfileAlert from "@/components/alert/profileAlert";
 import { EDIT_PROFILE_ALERT } from "@/constant/alert/alertText";
-import { useMutation, useQuery } from "@tanstack/react-query";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getUserProfile, patchProfile } from "@/service/client/userInfo";
 import { UpdateProfileBody, UpdateProfileParams } from "@/types/req/userInfo";
 import { useRouter } from "next/navigation";
@@ -32,8 +32,12 @@ export type ImageForm = {
 
 const ProfileSettingPage = () => {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const { mutate: updateProfile } = useMutation({
     mutationFn: (newProfile: UpdateProfile) => patchProfile(newProfile),
+    onSuccess() {
+      queryClient.invalidateQueries({ queryKey: ["userProfile"] });
+    },
   });
   const { data: profile } = useQuery({
     queryKey: ["userProfile"],

--- a/src/service/client/userInfo.ts
+++ b/src/service/client/userInfo.ts
@@ -104,11 +104,15 @@ async function patchProfile({
     .map(([key, value]) => `${key}=${value}`)
     .join("&");
   const url = `${endPoint.UPDATE_PROFILE}?${paramString}`;
-  const { data } = await clientHttp.patch<Profile>(url, body, {
-    headers: {
-      "Content-Type": "multipart/form-data",
-    },
-  });
+  const boundary = "----CustomWebKitFormBoundary673&%##*521654";
+  const headers = {
+    "Content-Type":
+      body === null
+        ? `multipart/form-data; boundary=${boundary}`
+        : `multipart/form-data`,
+  };
+
+  const { data } = await clientHttp.patch<Profile>(url, body, { headers });
 
   const { timeStamp, responseData } = data;
 


### PR DESCRIPTION
## #️⃣ 티켓

> 

## 📝작업 내용

> - null로 form-data를 보낼 경우, boundary가 설정되지 않아 수동으로 설정했습니다.
> - 이미지, 닉네임 수정후 바로 적용되도록 profile 캐시를 무효화시켰습니다

### 스크린샷 (선택)

